### PR TITLE
Normalize asset imports and refactor TopNav labels

### DIFF
--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -1,7 +1,9 @@
 ---
 import LocaleSwitcher from './LocaleSwitcher.jsx';
-import EthicappLogo from '../../assets/ethicapp-logo.png';
+import EthicappLogo from '/assets/EthicApp-logo.png';
+
 const { locale, nav } = Astro.props;
+const [homeLabel, featuresLabel, experiencesLabel, , researchLabel, teamLabel, developmentLabel, blogLabel] = nav;
 ---
 <header class="border-b border-slate-200 bg-white/90 backdrop-blur">
   <nav class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
@@ -9,13 +11,13 @@ const { locale, nav } = Astro.props;
       <img src={EthicappLogo.src} alt="EthicApp logo" class="brand-logo" />
     </a>
     <ul class="flex flex-wrap gap-4 text-sm font-medium text-slate-700">
-      <li><a href={`/${locale}/#inicio`}>{nav[0]}</a></li>
-      <li><a href={`/${locale}/#caracteristicas`}>{nav[1]}</a></li>
-      <li><a href={`/${locale}/#experiencias`}>{nav[2]}</a></li>
-      <li><a href={`/${locale}/#investigacion`}>{nav[4]}</a></li>
-      <li><a href={`/${locale}/#equipo`}>{nav[5]}</a></li>
-      <li><a href={`/${locale}/#desarrollo`}>{nav[6]}</a></li>
-      <li><a href={`/${locale}/blog/`}>{nav[7]}</a></li>
+      <li><a href={`/${locale}/#inicio`}>{homeLabel}</a></li>
+      <li><a href={`/${locale}/#caracteristicas`}>{featuresLabel}</a></li>
+      <li><a href={`/${locale}/#experiencias`}>{experiencesLabel}</a></li>
+      <li><a href={`/${locale}/#investigacion`}>{researchLabel}</a></li>
+      <li><a href={`/${locale}/#equipo`}>{teamLabel}</a></li>
+      <li><a href={`/${locale}/#desarrollo`}>{developmentLabel}</a></li>
+      <li><a href={`/${locale}/blog/`}>{blogLabel}</a></li>
     </ul>
     <LocaleSwitcher client:load currentLocale={locale} />
   </nav>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,7 +21,7 @@ import siteWebmanifest from '/assets/favicon/site.webmanifest';
     <link rel="apple-touch-icon" sizes="180x180" href={appleTouchIcon.src}>
     <link rel="icon" type="image/png" sizes="32x32" href={favicon32.src}>
     <link rel="icon" type="image/png" sizes="16x16" href={favicon16.src}>
-    <link rel="manifest" href={siteWebmanifest}>
+    <link rel="manifest" href={siteWebmanifest.src}>
   </head>
   <body class="bg-slate-50 font-sans text-slate-900">
     <slot />


### PR DESCRIPTION
### Motivation
- Ensure asset references resolve to actual URLs and improve readability of the top navigation by replacing index-based `nav` access with named variables.

### Description
- Updated logo import to `/assets/EthicApp-logo.png` and kept usage of `EthicappLogo.src` in the brand image.
- Replaced direct `nav[...]` index access with destructured label variables (`homeLabel`, `featuresLabel`, `experiencesLabel`, `researchLabel`, `teamLabel`, `developmentLabel`, `blogLabel`) in `src/components/TopNav.astro` and updated the corresponding link text.
- Fixed the web manifest link in `src/layouts/BaseLayout.astro` to use `siteWebmanifest.src` so the `<link rel="manifest">` points to the correct asset URL.
- Minor import and variable cleanup in the header/navigation template.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7538abf2c832bbfb2a106e5b4a832)