### PR TITLE
Fix asset imports, named nav labels, and blog CTA styling/text

### DIFF
--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -1,7 +1,9 @@
 ---
 import LocaleSwitcher from './LocaleSwitcher.jsx';
-import EthicappLogo from '../../assets/ethicapp-logo.png';
+import EthicappLogo from '/assets/EthicApp-logo.png';
+
 const { locale, nav } = Astro.props;
+const [homeLabel, featuresLabel, experiencesLabel, , researchLabel, teamLabel, developmentLabel, blogLabel] = nav;
 ---
 <header class="border-b border-slate-200 bg-white/90 backdrop-blur">
   <nav class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
@@ -9,13 +11,13 @@ const { locale, nav } = Astro.props;
       <img src={EthicappLogo.src} alt="EthicApp logo" class="brand-logo" />
     </a>
     <ul class="flex flex-wrap gap-4 text-sm font-medium text-slate-700">
-      <li><a href={`/${locale}/#inicio`}>{nav[0]}</a></li>
-      <li><a href={`/${locale}/#caracteristicas`}>{nav[1]}</a></li>
-      <li><a href={`/${locale}/#experiencias`}>{nav[2]}</a></li>
-      <li><a href={`/${locale}/#investigacion`}>{nav[4]}</a></li>
-      <li><a href={`/${locale}/#equipo`}>{nav[5]}</a></li>
-      <li><a href={`/${locale}/#desarrollo`}>{nav[6]}</a></li>
-      <li><a href={`/${locale}/blog/`}>{nav[7]}</a></li>
+      <li><a href={`/${locale}/#inicio`}>{homeLabel}</a></li>
+      <li><a href={`/${locale}/#caracteristicas`}>{featuresLabel}</a></li>
+      <li><a href={`/${locale}/#experiencias`}>{experiencesLabel}</a></li>
+      <li><a href={`/${locale}/#investigacion`}>{researchLabel}</a></li>
+      <li><a href={`/${locale}/#equipo`}>{teamLabel}</a></li>
+      <li><a href={`/${locale}/#desarrollo`}>{developmentLabel}</a></li>
+      <li><a href={`/${locale}/blog/`}>{blogLabel}</a></li>
     </ul>
     <LocaleSwitcher client:load currentLocale={locale} />
   </nav>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,7 +21,7 @@ import siteWebmanifest from '/assets/favicon/site.webmanifest';
     <link rel="apple-touch-icon" sizes="180x180" href={appleTouchIcon.src}>
     <link rel="icon" type="image/png" sizes="32x32" href={favicon32.src}>
     <link rel="icon" type="image/png" sizes="16x16" href={favicon16.src}>
-    <link rel="manifest" href={siteWebmanifest}>
+    <link rel="manifest" href={siteWebmanifest.src}>
   </head>
   <body class="bg-slate-50 font-sans text-slate-900">
     <slot />

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -184,7 +184,14 @@ const institutions = [
 
   <section id="blog" class="mx-auto max-w-6xl px-6 py-10">
     <h2 class="text-3xl font-semibold">{t.blog}</h2>
-    <p class="mt-3"><a class="text-blue-700 underline" href={`/${locale}/blog/`}>Ir al blog</a></p>
+    <p class="mt-4">
+      <a
+        class="inline-flex items-center rounded-md bg-[rgb(29_78_216)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:brightness-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(29_78_216)]"
+        href={`/${locale}/blog/`}
+      >
+        {isEs ? "Ir al blog" : "Go to blog"}
+      </a>
+    </p>
   </section>
 
   <CTA label={t.developmentTitle} />


### PR DESCRIPTION
### Motivation
- Ensure static assets resolve correctly and avoid case/path mismatches for images and webmanifest.
- Improve readability and maintainability of the top navigation by using named label variables instead of numeric `nav` indices.
- Provide a clearer call-to-action for the blog section with localized text and improved styling.

### Description
- Updated logo import path and filename to use the correct `/assets/EthicApp-logo.png` path and used `EthicappLogo.src` for the `img` `src` attribute in `TopNav.astro`.
- Destructured the `nav` array into named variables (`homeLabel`, `featuresLabel`, `experiencesLabel`, `researchLabel`, `teamLabel`, `developmentLabel`, `blogLabel`) and replaced inline `nav[index]` usages with those variables in `TopNav.astro`.
- Fixed the webmanifest link in `BaseLayout.astro` to reference `siteWebmanifest.src` so the manifest path resolves correctly at runtime.
- Reworked the blog link in `src/pages/[locale]/index.astro` into a styled CTA button and made its label localized (`{isEs ? "Ir al blog" : "Go to blog"}`) while adjusting spacing classes.

### Testing
- Ran the project build with `npm run build` (Astro) and the build completed successfully.
- Performed a smoke check of the rendered pages locally, confirming the header logo, manifest link, navigation labels, and blog CTA render as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7538abf2c832bbfb2a106e5b4a832)