### PR TITLE
Add AGENTS.md and README updates; fix asset imports, nav labels, and blog CTA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+# AGENTS.md — EthicApp Website Maintenance Guide
+
+This document gives autonomous/code agents the minimum operational context needed to safely maintain this repository.
+
+## 1) Project purpose
+
+- **Project**: EthicApp public website.
+- **Type**: Brochure/informational site with a localized blog.
+- **Audience**: Visitors looking for project overview, features, team, research, and updates.
+- **Tech stack**: **Astro + Vite + Tailwind CSS**, with some React components where useful.
+
+## 2) Core architecture
+
+- `src/pages/`
+  - Route files (`.astro`) define pages.
+  - `src/pages/[locale]/...` contains localized routes.
+- `src/components/`
+  - Reusable UI sections (navigation, hero, features, CTA, etc.).
+- `src/layouts/`
+  - Shared layout wrappers (metadata, global links such as favicon/manifest, page shell).
+- `src/lib/`
+  - Utilities such as i18n helpers.
+- `src/content/`
+  - Blog content in Markdown, organized by locale (`en`, `es`).
+- `src/content.config.ts`
+  - Content collections schema validation for blog frontmatter.
+- `assets/`
+  - Static visual assets (logos, screenshots, favicons, manifest).
+- `.github/workflows/deploy.yml`
+  - CI/CD workflow for build + deploy to GitHub Pages.
+
+## 3) Content model and localization
+
+- Blog entries are Markdown files under `src/content/blog/<locale>/`.
+- Required frontmatter fields are validated by Astro content collections:
+  - `title` (string)
+  - `description` (string)
+  - `pubDate` (date)
+  - `locale` (`es` or `en`)
+  - `draft` (boolean, defaults to `false`)
+- Keep locale consistency:
+  - Files in `blog/es` should use `locale: es`.
+  - Files in `blog/en` should use `locale: en`.
+- Prefer adding translations in both locales when publishing new informational content.
+
+## 4) Build, run, and verification commands
+
+Use npm scripts from `package.json`:
+
+- `npm run dev` → start local dev server.
+- `npm run build` → production build (must pass before merge).
+- `npm run preview` → preview production build locally.
+
+For agent changes, run **at least** `npm run build` as a validation check.
+
+## 5) Deployment model (GitHub Actions)
+
+- Deployment is handled by `.github/workflows/deploy.yml`.
+- Trigger conditions:
+  - Push to `main` branch.
+  - Manual trigger (`workflow_dispatch`).
+- Workflow behavior:
+  1. Checks out repository.
+  2. Runs Astro build via `withastro/action@v3`.
+  3. Deploys artifact to GitHub Pages via `actions/deploy-pages@v4`.
+
+## 6) Asset and path conventions (important)
+
+- When importing assets in Astro components/layouts, prefer ESM imports and use `.src` when required by Astro/Vite processing.
+- Respect exact filename casing (e.g., `EthicApp-logo.png` vs other case variants).
+- Keep favicon/manifest wiring in the main layout consistent with imported asset references.
+- Before finishing, ensure no broken static imports by running `npm run build`.
+
+## 7) Styling conventions
+
+- Tailwind is the primary styling system.
+- Prefer utility classes in components/pages over ad-hoc CSS unless truly reusable.
+- Keep color usage aligned with EthicApp design tokens/palette already in use.
+- Preserve accessibility basics on interactive elements (hover/focus-visible states, semantic controls).
+
+## 8) Change safety checklist for agents
+
+Before committing:
+
+1. Confirm route/component imports resolve.
+2. Confirm blog schema compliance for added/edited markdown frontmatter.
+3. Run `npm run build` successfully.
+4. Keep changes minimal and scoped to the request.
+5. Document user-visible behavior changes in commit/PR notes.
+
+## 9) Legacy folder note
+
+- `legacy-site/` contains previous site artifacts and historical references.
+- Do **not** modify `legacy-site/` for normal feature/fix work unless the task explicitly requires it.
+
+---
+
+If this guide conflicts with direct user/developer/system instructions, follow those higher-priority instructions.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,104 @@
-# EthicApp site-v2 prototype
+# EthicApp Website
 
-Prototype brochure + blog built with:
-- Astro
-- React islands
-- Tailwind
-- MDX/content collections with locales (`es`, `en`)
+Informational (brochure-style) website for the **EthicApp** project, including a localized blog powered by Markdown content.
 
-## Run
+## Purpose
+
+This repository contains the public-facing site used to communicate:
+
+- What EthicApp is and why it exists.
+- Key product capabilities and educational value.
+- Research, team, and institutional context.
+- News and updates through a bilingual blog (`es` and `en`).
+
+The site is designed to be lightweight, easy to maintain, and simple to deploy.
+
+## Customizable Content
+
+Most project updates can be made by editing content files and component text without changing core infrastructure.
+
+### 1) Pages and sections
+
+- Main localized pages live in `src/pages/[locale]/`.
+- Shared and reusable sections (hero, features, CTA, top nav, etc.) live in `src/components/`.
+- Global page wrapper and metadata (including favicon/manifest links) live in `src/layouts/BaseLayout.astro`.
+
+### 2) Blog posts (Markdown)
+
+- Blog content lives in `src/content/blog/` split by locale:
+  - `src/content/blog/es/`
+  - `src/content/blog/en/`
+- Posts use frontmatter validated by `src/content.config.ts`.
+- Current schema fields:
+  - `title`
+  - `description`
+  - `pubDate`
+  - `locale` (`es` or `en`)
+  - `draft` (optional, defaults to `false`)
+
+### 3) Visual assets
+
+- Images, logos, screenshots, and favicon assets are stored under `assets/`.
+- Keep exact filename casing when importing assets (important for CI/Linux builds).
+
+### 4) Localization
+
+- The site supports Spanish and English routes.
+- Ensure content labels and blog metadata match the intended locale.
+
+## Technology Stack
+
+- **Astro** (site framework and routing)
+- **Vite** (build tool used by Astro)
+- **Tailwind CSS** (styling)
+- **React** (interactive islands/components where needed)
+- **Astro Content Collections + Markdown/MDX** (structured blog content)
+
+## Development
+
+### Requirements
+
+- Node.js (LTS recommended)
+- npm
+
+### Install and run
 
 ```bash
-cd site-v2
 npm install
 npm run dev
 ```
 
-Routes:
-- `/es/`
-- `/en/`
-- `/es/blog/`
-- `/en/blog/`
+### Build and preview
+
+```bash
+npm run build
+npm run preview
+```
+
+## Deployment
+
+Deployment is automated with **GitHub Actions** using `.github/workflows/deploy.yml`.
+
+- Triggered on pushes to `main` (and manual workflow dispatch).
+- Builds the site and deploys to GitHub Pages.
+
+## Project Structure (high level)
+
+```text
+.
+├─ src/
+│  ├─ components/      # Reusable UI sections
+│  ├─ layouts/         # Shared page layout
+│  ├─ lib/             # Utilities (e.g., i18n helpers)
+│  ├─ pages/           # File-based routes
+│  ├─ content/         # Blog markdown by locale
+│  └─ content.config.ts
+├─ assets/             # Static images, logos, favicons, manifest
+└─ .github/workflows/  # CI/CD deployment workflow
+```
+
+## Notes for Contributors
+
+- Prefer small, focused changes.
+- Run `npm run build` before opening or merging changes.
+- If editing blog content, verify frontmatter fields and locale consistency.

--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -1,7 +1,9 @@
 ---
 import LocaleSwitcher from './LocaleSwitcher.jsx';
-import EthicappLogo from '../../assets/ethicapp-logo.png';
+import EthicappLogo from '/assets/EthicApp-logo.png';
+
 const { locale, nav } = Astro.props;
+const [homeLabel, featuresLabel, experiencesLabel, , researchLabel, teamLabel, developmentLabel, blogLabel] = nav;
 ---
 <header class="border-b border-slate-200 bg-white/90 backdrop-blur">
   <nav class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
@@ -9,13 +11,13 @@ const { locale, nav } = Astro.props;
       <img src={EthicappLogo.src} alt="EthicApp logo" class="brand-logo" />
     </a>
     <ul class="flex flex-wrap gap-4 text-sm font-medium text-slate-700">
-      <li><a href={`/${locale}/#inicio`}>{nav[0]}</a></li>
-      <li><a href={`/${locale}/#caracteristicas`}>{nav[1]}</a></li>
-      <li><a href={`/${locale}/#experiencias`}>{nav[2]}</a></li>
-      <li><a href={`/${locale}/#investigacion`}>{nav[4]}</a></li>
-      <li><a href={`/${locale}/#equipo`}>{nav[5]}</a></li>
-      <li><a href={`/${locale}/#desarrollo`}>{nav[6]}</a></li>
-      <li><a href={`/${locale}/blog/`}>{nav[7]}</a></li>
+      <li><a href={`/${locale}/#inicio`}>{homeLabel}</a></li>
+      <li><a href={`/${locale}/#caracteristicas`}>{featuresLabel}</a></li>
+      <li><a href={`/${locale}/#experiencias`}>{experiencesLabel}</a></li>
+      <li><a href={`/${locale}/#investigacion`}>{researchLabel}</a></li>
+      <li><a href={`/${locale}/#equipo`}>{teamLabel}</a></li>
+      <li><a href={`/${locale}/#desarrollo`}>{developmentLabel}</a></li>
+      <li><a href={`/${locale}/blog/`}>{blogLabel}</a></li>
     </ul>
     <LocaleSwitcher client:load currentLocale={locale} />
   </nav>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,7 +21,7 @@ import siteWebmanifest from '/assets/favicon/site.webmanifest';
     <link rel="apple-touch-icon" sizes="180x180" href={appleTouchIcon.src}>
     <link rel="icon" type="image/png" sizes="32x32" href={favicon32.src}>
     <link rel="icon" type="image/png" sizes="16x16" href={favicon16.src}>
-    <link rel="manifest" href={siteWebmanifest}>
+    <link rel="manifest" href={siteWebmanifest.src}>
   </head>
   <body class="bg-slate-50 font-sans text-slate-900">
     <slot />

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -184,7 +184,14 @@ const institutions = [
 
   <section id="blog" class="mx-auto max-w-6xl px-6 py-10">
     <h2 class="text-3xl font-semibold">{t.blog}</h2>
-    <p class="mt-3"><a class="text-blue-700 underline" href={`/${locale}/blog/`}>Ir al blog</a></p>
+    <p class="mt-4">
+      <a
+        class="inline-flex items-center rounded-md bg-[rgb(29_78_216)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:brightness-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgb(29_78_216)]"
+        href={`/${locale}/blog/`}
+      >
+        {isEs ? "Ir al blog" : "Go to blog"}
+      </a>
+    </p>
   </section>
 
   <CTA label={t.developmentTitle} />


### PR DESCRIPTION
### Motivation

- Provide explicit operational guidance for autonomous/code agents and contributors by adding an `AGENTS.md` maintenance guide. 
- Fix runtime asset import resolution and manifest wiring to avoid broken static imports on CI/production. 
- Improve readability and maintainability of the top navigation by naming nav entries and centralizing label usage. 
- Improve the blog link UX with a localized, accessible CTA and update repository docs for contributors.

### Description

- Add `AGENTS.md` containing project purpose, architecture, content/localization rules, build/run guidance, deployment notes, and a safety checklist for agent edits. 
- Revise `README.md` to expand purpose, structure, development, build, and deployment instructions and to emphasize localization and content conventions. 
- Update `src/components/TopNav.astro` to import the logo from `/assets/EthicApp-logo.png` and destructure the `nav` array into named labels for clearer template usage. 
- Change `src/layouts/BaseLayout.astro` to reference the webmanifest using `siteWebmanifest.src` so the manifest resolves correctly at runtime. 
- Update `src/pages/[locale]/index.astro` to replace the blog text link with a styled localized CTA button that displays `Ir al blog` for Spanish and `Go to blog` for other locales.

### Testing

- Run `npm run build` and the production build completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7538abf2c832bbfb2a106e5b4a832)