### PR TITLE
Add first bilingual blog post about UVa teacher training course

### DIFF
--- a/src/content/blog/en/first-post.md
+++ b/src/content/blog/en/first-post.md
@@ -1,10 +1,10 @@
 ---
-title: "First EthicApp v2 post"
-description: "We launched the new Astro + React islands + Tailwind site prototype."
-pubDate: 2026-05-02
+title: "Teacher Training Course at the University of Valladolid"
+description: "Researchers Claudio Álvarez and Gustavo Zurita participated as lecturers in the teacher training course \"Design of Ethical Cases and Teaching Strategies with EthicApp\", organized by the Teaching Innovation Laboratory of the University of Valladolid (LIDUva). The three-session course was held twice, during March and April 2026. It was led by Dr. Yannis Dimitriadis, Full Professor at the same institution and Director of the historic GSIC/EMIC research group (Intelligent and Cooperative Systems / Education, Media, Computer Science and Culture). Dr. Alejandra Martínez, Full Professor at UVa and GSIC/EMIC researcher, also participated."
+pubDate: 2026-05-04
 locale: en
 ---
 
-This is the first blog post for the **site-v2** prototype.
+The course brought together academics from different academic units at UVa and covered theory on moral psychology, ethical reasoning and decision-making, and instructional design for the case-method approach.
 
-We'll share product updates, research notes, and development progress here.
+On the practical side, it included the design and implementation of activities for EthicApp by participants, along with participation in model EthicApp cases on research ethics and academic ethics.

--- a/src/content/blog/es/primer-post.md
+++ b/src/content/blog/es/primer-post.md
@@ -1,10 +1,10 @@
 ---
-title: "Primer post de EthicApp v2"
-description: "Lanzamos el prototipo del nuevo sitio en Astro + React islands + Tailwind."
-pubDate: 2026-05-02
+title: "Curso de formación docente en Universidad de Valladolid"
+description: "Los investigadores Claudio Álvarez y Gustavo Zurita participaron como relatores en el curso de formación docente \"Diseño de casos éticos y estrategias de enseñanza con Ethicapp\", del Laboratorio de Innovación Docente de la Universidad de Valladolid (LIDUva). El curso de tres sesiones fue realizado en dos oportunidades, en los meses de marzo y abril de 2026. Fue liderado por el Dr. Yannis Dimitriadis, Catedrático de la misma institución, Director del histórico grupo de investigación GSIC/EMIC (Grupo de Sistemas Inteligentes y Cooperativos / Educación, Medios, Informática y Cultura). También participó la Dra. Alejandra Martínez, Catedrática de la UVa e investigadora de GSIC/EMIC."
+pubDate: 2026-05-04
 locale: es
 ---
 
-Este es el primer post del blog del prototipo **site-v2**.
+El curso contó con la participación de académicos de distintas unidades académicas de la UVa, y cubrió teoría sobre psicología moral, razonamiento y toma de decisiones éticas, y diseño instruccional para metodología de casos.
 
-Aquí iremos publicando novedades del proyecto, avances de investigación y desarrollo.
+En lo práctico, incluyó el diseño e implementación de actividades por parte de los participantes para EthicApp, junto con la participación en casos ejemplares con EthicApp sobre ética en la investigación y ética académica.


### PR DESCRIPTION
### Motivation
- Add the first official bilingual blog entry describing the teacher training course at the University of Valladolid to replace the initial placeholder posts and document the project's teaching/outreach activity.

### Description
- Update `src/content/blog/es/primer-post.md` with the Spanish post including frontmatter `title`, `description`, `pubDate: 2026-05-04`, and `locale: es` plus the Spanish body text.
- Update `src/content/blog/en/first-post.md` with the English translation including frontmatter `title`, `description`, `pubDate: 2026-05-04`, and `locale: en` plus the English body text, keeping both files aligned with the content collection schema in `src/content.config.ts`.

### Testing
- Ran `npm run build`, which completed successfully and produced the static site output including the new blog pages.
- Content syncing and type generation completed without errors, validating frontmatter schema compliance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76cc67388832bafb19838258a30cf)