### PR TITLE
Corregir fondo repetido y tipografía en entradas del blog

### DIFF
--- a/src/pages/[locale]/blog/[...slug].astro
+++ b/src/pages/[locale]/blog/[...slug].astro
@@ -17,9 +17,61 @@ const { Content } = await render(post);
 ---
 <BaseLayout title={post.data.title}>
   <TopNav locale={post.data.locale} nav={copy[post.data.locale].nav} />
-  <article class="prose prose-slate mx-auto px-6 py-12">
-    <a href={`/${post.data.locale}/blog/`}>&larr; Volver / Back</a>
+  <article class="mx-auto max-w-4xl px-6 py-12 text-slate-900">
+    <a class="inline-block text-2xl font-semibold no-underline hover:underline" href={`/${post.data.locale}/blog/`}>&larr; Volver / Back</a>
     <h1>{post.data.title}</h1>
-    <Content />
+    <div class="blog-content mt-8">
+      <Content />
+    </div>
   </article>
 </BaseLayout>
+
+<style is:global>
+  .blog-content {
+    font-size: 1.3rem;
+    line-height: 1.5;
+  }
+
+  .blog-content h1,
+  .blog-content h2,
+  .blog-content h3,
+  .blog-content h4 {
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    font-weight: 800;
+    line-height: 1.2;
+    color: rgb(15 23 42);
+  }
+
+  .blog-content h1 {
+    font-size: 2.6rem;
+  }
+
+  .blog-content h2 {
+    font-size: 2.1rem;
+  }
+
+  .blog-content h3 {
+    font-size: 1.8rem;
+  }
+
+  .blog-content p,
+  .blog-content ul,
+  .blog-content ol,
+  .blog-content blockquote {
+    margin: 1rem 0;
+  }
+
+  .blog-content ul,
+  .blog-content ol {
+    padding-left: 1.5rem;
+  }
+
+  .blog-content ul {
+    list-style: disc;
+  }
+
+  .blog-content ol {
+    list-style: decimal;
+  }
+</style>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -7,6 +7,9 @@
 
 body {
   background: var(--ea-surface-gradient);
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-attachment: fixed;
 }
 
 a {


### PR DESCRIPTION
### Motivation
- Las entradas del blog mostraban el gradiente de fondo repetido y los headings no estaban bien formateados porque la plantilla dependía de las clases `prose` de Tailwind que no estaban configuradas. 
- Se buscó una solución mínima y localizada para restaurar la legibilidad del contenido sin introducir configuración extra de Tailwind.

### Description
- Ajusté el fondo global en `src/styles/theme.css` añadiendo `background-repeat: no-repeat`, `background-size: cover` y `background-attachment: fixed` para evitar la repetición del gradiente en la página.  
- Reemplacé la dependencia en `prose` en `src/pages/[locale]/blog/[...slug].astro` por un contenedor `article` con `max-w-4xl` y un enlace de retorno con clases de Tailwind para mejor legibilidad.  
- Añadí un bloque de estilos globales (`<style is:global>`) en la misma página para definir tipografías y espaciados explícitos para `.blog-content` y sus `h1`-`h4`, párrafos y listas, restaurando el formato esperado del Markdown renderizado.  
- Cambios principales en archivos: `src/styles/theme.css` y `src/pages/[locale]/blog/[...slug].astro`.

### Testing
- Ejecuté `npm run build` y la compilación de Astro finalizó correctamente sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7baa96ac0832b842eb71684dd543f)